### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-enable-pre-post-scripts=true

--- a/Dockerfile.pnpm
+++ b/Dockerfile.pnpm
@@ -1,5 +1,5 @@
-ARG NODE_VERSION="20.9.0"
-ARG PNPM_VERSION="8.15.8"
+ARG NODE_VERSION="24.13.0"
+ARG PNPM_VERSION="11.3.0"
 
 ##
 # Create base image with pnpm installed 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Tested with:
 
 - **Node.js v24.13.0**
-- **pnpm v10.28.2**
+- **pnpm v11.3.0**
 - **vitest v4.0.18**
 
 ---

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - 'packages/*'
+allowBuilds:
+  esbuild: true
+enablePrePostScripts: true


### PR DESCRIPTION
## Summary
- pin the workspace package manager to pnpm 11.3.0
- move pnpm-specific config from .npmrc to pnpm-workspace.yaml
- allow esbuild build scripts explicitly for pnpm 11 strict build approvals
- align the Docker pnpm base image with Node 24.13.0 and pnpm 11.3.0

## Verification
- CI=true pnpm install --frozen-lockfile
- pnpm build
- pnpm check:exports
- pnpm lint:ci
- pnpm test
- docker build -f Dockerfile.pnpm --target jkomyno-pnpm .
